### PR TITLE
fix for OS architecture type detection

### DIFF
--- a/lib/iedriver.js
+++ b/lib/iedriver.js
@@ -1,6 +1,6 @@
 var path = require('path');
 process.env.PATH += path.delimiter + path.join(__dirname, 'iedriver');
-exports.path = process.platform === 'win32' ?
+exports.path = process.arch === 'ia32' ?
 path.join(__dirname, 'iedriver', 'IEDriverServer.exe') :
 path.join(__dirname, 'iedriver', 'IEDriverServer64.exe');
 exports.binaryversion = '3.0.0';


### PR DESCRIPTION
process.platform === 'win32' is for Winx32 and Winx64
https://nodejs.org/api/process.html#process_process_platform

to detect OS architecture you should use process.arch
https://nodejs.org/api/process.html#process_process_arch