### PR TITLE
Add extract-zip dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "adm-zip": "0.2.1",
+    "extract-zip": "1.6.6",
     "kew": "~0.1.7",
     "md5-file": "^1.1.4",
     "mkdirp": "0.3.5",


### PR DESCRIPTION
This dependency is required here: https://github.com/barretts/node-iedriver/blob/30e8e431f4f9c32bccdb7704c18c649b38f94581/install.js#L16

Without this dependency it will result right now in the following error when executing `npm install`:
```
> iedriver@3.9.1 install /Users/maikel/git/opensource/node-iedriver
> node install.js

module.js:557
    throw err;
    ^

Error: Cannot find module 'extract-zip'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/maikel/git/opensource/node-iedriver/install.js:16:15)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)```