### PR TITLE
getting the proxy config

### DIFF
--- a/install.js
+++ b/install.js
@@ -119,8 +119,10 @@ function requestBinary(_downloadUrl, filePath) {
   
   var deferred = kew.defer()
 
-  request
-    .get(_downloadUrl)
+  const requestOptions = getRequestOptions(_downloadUrl)
+  const client = request(requestOptions)        
+
+  client
     .on('error', function (err) {
       deferred.reject('Error with http request: ' + util.inspect(response.headers))
     })
@@ -132,6 +134,14 @@ function requestBinary(_downloadUrl, filePath) {
   return deferred.promise
 }
 
+function getRequestOptions(_downloadUrl) {
+  const options = {uri: _downloadUrl, method: 'GET'};
+  const proxyUrl =  process.env.npm_config_https_proxy || process.env.npm_config_proxy || process.env.npm_config_http_proxy;
+  if (proxyUrl) {
+    options.proxy = proxyUrl;
+  }
+  return options;
+}
 
 function validateMd5(filePath, md5value) {
   var deferred = kew.defer()


### PR DESCRIPTION
NPM to work behind a proxy requires setting the proxy, https-proxy and https-proxy settings. 

So I have already tried

npm config set proxy http://DOMAIN\\username:password@proxy:port

npm config set http-proxy http://DOMAIN\\username:password@proxy:port 

npm config set https-proxy http://DOMAIN\\username:password@proxy:port 

but it did not work.

So i saw the chromedriver install script 

https://github.com/giggio/node-chromedriver/blob/master/install.js

and fixed the problem.