### PR TITLE
[install] inspect the whole error on failures

### DIFF
--- a/install.js
+++ b/install.js
@@ -127,7 +127,7 @@ function requestBinary(_downloadUrl, filePath) {
 
   client
     .on('error', function (err) {
-      deferred.reject('Error with http request: ' + util.inspect(response.headers))
+      deferred.reject('Error with http request: ' + util.inspect(err))
     })
     .on('end', function () {
       deferred.resolve(true)


### PR DESCRIPTION
Fixes https://github.com/barretts/node-iedriver/issues/26

Rather than trying to log the headers we should just log the whole error as it can take a lot of possible shapes.